### PR TITLE
Refactored to use template inheritance and url template tags

### DIFF
--- a/rango/urls.py
+++ b/rango/urls.py
@@ -7,6 +7,6 @@ urlpatterns = [
     url(r'^add_category/$', views.add_category, name='add_category'),
     url(r'^category/(?P<category_name_slug>[\w\-]+)/$',
         views.show_category, name='show_category'),
-    url(r'^category/(?P<category_name_slug>[\w\-]+)/add_page/$', views.add_page, name='add_page'),
-  
+    url(r'^category/(?P<category_name_slug>[\w\-]+)/add_page/$',
+        views.add_page, name='add_page'),
 ]

--- a/templates/rango/about.html
+++ b/templates/rango/about.html
@@ -1,19 +1,14 @@
-<!DOCTYPE html>
-
+{% extends 'rango/base.html' %}
 {% load staticfiles %}
 
-<html>
-    <head>
-        <title>Rango</title>
-    </head>
-
-    <body>
-        <h1>Rango says...</h1>
-    <div>
-        This tutorial has been put together by Grenouille <br />
-    </div>
-    <div>
-        <a href="/rango/">Home</a><br />
-        <img src="{{ MEDIA_URL }}cat.jpeg"
-             alt="Picture of a cat"/>
-    </div>
+{% block body_block %}
+    <h1>Rango says...</h1>
+<div>
+    This tutorial has been put together by Grenouille <br />
+</div>
+<div>
+    <a href={% url 'home' %}>Home</a><br />
+    <img src="{{ MEDIA_URL }}cat.jpeg"
+         alt="Picture of a cat"/>
+</div>
+{% endblock %}

--- a/templates/rango/add_category.html
+++ b/templates/rango/add_category.html
@@ -1,24 +1,20 @@
-<!DOCTYPE html>
-<html>
-    <head>
-        <title>Rango</title>
-    </head>
+{% extends 'rango/base.html' %}
+{% load staticfiles %}
 
-    <body>
-        <h1>Add a Category</h1>
-        <div>
-            <form id="category_form" method="post" action="/rango/add_category/">
-                {% csrf_token %}
-                {% for hidden in form.hidden_fields %}
-                    {{ hidden }}
-                {% endfor %}
-                {% for field in form.visible_fields %}
-                    {{ field.errors }}
-                    {{ field.help_text }}
-                    {{ field }}
-                {% endfor %}
-                <input type="submit" name="submit" value="Create Category" />
-            </form>
-        </div>
-    </body>
-</html>
+{% block body_block %}
+    <h1>Add a Category</h1>
+    <div>
+        <form id="category_form" method="post" action="/rango/add_category/">
+            {% csrf_token %}
+            {% for hidden in form.hidden_fields %}
+                {{ hidden }}
+            {% endfor %}
+            {% for field in form.visible_fields %}
+                {{ field.errors }}
+                {{ field.help_text }}
+                {{ field }}
+            {% endfor %}
+            <input type="submit" name="submit" value="Create Category" />
+        </form>
+    </div>
+{% endblock %}

--- a/templates/rango/base.html
+++ b/templates/rango/base.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+{% load staticfiles %}
+
+<html>
+    <head lang="en">
+        <meta charset="UTF-8" />
+        <title>
+            Rango -
+            {% block title-block %}
+                How to Tango with Django
+            {% endblock %}
+        </title>
+    </head>
+    <body>
+        <div>
+            {% block body_block %}
+            {% endblock %}
+        </div>
+        <hr />
+        <div>
+            <ul>
+                {% block footer_block %}
+                    <li><a href="{% url 'add_category' %}">Add New Category</a></li>
+                    <li><a href="{% url 'about' %}">About</a></li>
+                    <li><a href="{% url 'index' %}">Index</a></li>
+                {% endblock %}
+            </ul>
+        </div>
+    </body>
+</html>

--- a/templates/rango/category.html
+++ b/templates/rango/category.html
@@ -1,12 +1,14 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Rango</title>
-</head>
-<body>
-    <div>
+{% extends 'rango/base.html' %}
+{% load staticfiles %}
+
+{% block title_block %}
+    {{ category.name }}
+{% endblock %}
+
+{% block body_block %}
     {% if category %}
         <h1>{{ category.name }}</h1>
+        
         {% if pages %}
             <ul>
             {% for page in pages %}
@@ -19,10 +21,11 @@
     {% else %}
         The specified category does not exist!
     {% endif %}
-    </div>
-    <div>
-        <a href="/rango/category/{{ category.slug }}/add_page">Add Page</a><br />
-        <a href="/">Index</a>
-    </div>
-</body>
-</html>
+{% endblock %}
+
+{% block footer_block %}
+    <li><a href="{% url 'add_page' category.slug %}">Add a Page</a></li>
+    <li><a href="{% url 'about' %}">About</a></li>
+    <li><a href="{% url 'index' %}">Index</a></li>
+{% endblock %}
+

--- a/templates/rango/index.html
+++ b/templates/rango/index.html
@@ -1,14 +1,7 @@
-<!DOCTYPE html>
-
+{% extends 'rango/base.html' %}
 {% load staticfiles %} <!-- New line -->
 
-<html>
-
-<head>
-    <title>Rango</title>
-</head>
-
-<body>
+{% block body_block %}
     <h1>Rango says...</h1>
     <div>hey there partner!</div>
 
@@ -43,10 +36,7 @@
     </div>
 
     <div>
-        <a href="/rango/about/">About</a><br />
-        <a href="/rango/add_category/">Add a New Category</a><br />
         <img src="{% static "images/rango-2.png" %}"
             alt="Picture of Rango" /> <!-- New line -->
     </div>
-</body>
-</html>
+{% endblock %}


### PR DESCRIPTION
In this commit I added template inheritance. There was a lot of similar code in all html templates. All similar code was put in a base.html template and all other templates inherited from that and overode what was necessary.
Also to help with maintainability of code, instead of hard-coding url paths I used a url template tag to enable reverse matching of urls using the name variable in urls.py